### PR TITLE
[WIP] removed sklearn integration test stub for FastRGF

### DIFF
--- a/tests/test_rgf_python.py
+++ b/tests/test_rgf_python.py
@@ -354,12 +354,6 @@ class TestFastRGFClassfier(RGFClassfierBaseTest, unittest.TestCase):
         else:
             self.assertEqual(clf.min_samples_leaf_, clf.min_samples_leaf)
 
-    def test_sklearn_integration(self):
-        # TODO(fukatani): FastRGF bug?
-        # FastRGF doesn't work if the number of sample is too small.
-        # check_estimator(self.classifier_class)
-        pass
-
 
 class RGFRegressorBaseTest(object):
     def setUp(self):
@@ -636,10 +630,3 @@ class TestFastRGFRegressor(RGFRegressorBaseTest, unittest.TestCase):
     def test_parallel_gridsearch(self):
         self.kwargs['n_jobs'] = 1
         super(TestFastRGFRegressor, self).test_parallel_gridsearch()
-
-    def test_sklearn_integration(self):
-        # TODO(fukatani): FastRGF bug?
-        # FastRGF discretization doesn't work if the number of sample is too
-        # small.
-        # check_estimator(self.regressor_class)
-        pass


### PR DESCRIPTION
@fukatani It seems that recent code updates in FastRGF repo changed the behavior in case of small #data.

As you can see, now sklearn integration test fails only in Python 3.4 environment. Strangely, on my local machine (Windows x64, Python 3.6) FastRGF keeps crashing in case #samples < 28 of boston dataset...

Do you have any ideas or other strange behavior cases on your local machine?